### PR TITLE
Webhooks for cron schedules (ENG-3355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ Timeout 10s; any `2xx` counts as delivered. On connection errors, timeouts,
 `5xx`, `408` or `429` mymeet retries up to 5 times (~1m, 5m, 15m, 1h, 3h, with
 jitter); other `4xx` are not retried. Delivery is **at-least-once**: after a
 manual restart of a failed meeting you may receive `meeting.failed` and later
-`meeting.completed` — deduplicate by `meeting_id` + `event`. Webhooks are not
-available for `cron` schedules yet (`400`).
+`meeting.completed` — deduplicate by `meeting_id` + `event`. For `cron`
+schedules every firing produces its own meeting and sends its own notification
+with that meeting's `meeting_id`; deleting the schedule stops the
+notifications.
 
 ## Get meeting list DEPRECATED!!! Gives only old meetings. Use approach bellow
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,11 @@ Timeout 10s; any `2xx` counts as delivered. On connection errors, timeouts,
 `5xx`, `408` or `429` mymeet retries up to 5 times (~1m, 5m, 15m, 1h, 3h, with
 jitter); other `4xx` are not retried. Delivery is **at-least-once**: after a
 manual restart of a failed meeting you may receive `meeting.failed` and later
-`meeting.completed` — deduplicate by `meeting_id` + `event`. For `cron`
-schedules every firing produces its own meeting and sends its own notification
-with that meeting's `meeting_id`; deleting the schedule stops the
-notifications.
+`meeting.completed` — deduplicate by `X-Mymeet-Delivery` (unique per
+notification). For `cron` schedules every firing records a meeting and sends
+its own notification; the whole series shares the schedule's `meeting_id`
+(the one returned by the scheduling request), each firing's report replacing
+the previous one.
 
 ## Get meeting list DEPRECATED!!! Gives only old meetings. Use approach bellow
 


### PR DESCRIPTION
Phase 2 of the webhooks feature: the cron limitation is lifted — every schedule firing sends its own `meeting.completed`/`meeting.failed` with that meeting's `meeting_id`; deleting the schedule stops the notifications.

Pairs with [Backend#841](https://github.com/MyMeetAI/Backend/pull/841) and [BotsService#536](https://github.com/MyMeetAI/BotsService/pull/536) — merge together.